### PR TITLE
Fixed issue with mineable/pickaxe tag failing to generate

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -3,7 +3,10 @@
   "values": [
     "pipez:energy_pipe",
     "pipez:fluid_pipe",
-    "pipez:gas_pipe",
+    {
+      "id": "pipez:gas_pipe",
+      "required": false
+    },
     "pipez:item_pipe",
     "pipez:universal_pipe"
   ]


### PR DESCRIPTION
Due to item: pipez:gas_pipe not existing Minecraft fails to gen the mineable/pickaxe tag.

https://pste.me/v1/paste/O_gzOm_2oRQ/raw