### PR TITLE
Drag and drop item, fluid, gas to hover area for set filter

### DIFF
--- a/src/main/java/de/maxhenkel/pipez/gui/FilterScreen.java
+++ b/src/main/java/de/maxhenkel/pipez/gui/FilterScreen.java
@@ -27,6 +27,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
 import org.lwjgl.glfw.GLFW;
 
@@ -269,20 +270,38 @@ public class FilterScreen extends ScreenBase<FilterContainer> {
                 nbt.setValue("");
             }
         } else if (filter instanceof FluidFilter) {
-            FluidUtil.getFluidContained(stack).ifPresent(s -> {
-                item.setValue(s.getFluid().getRegistryName().toString());
-                if (s.hasTag()) {
-                    nbt.setValue(s.getTag().toString());
-                } else {
-                    nbt.setValue("");
-                }
-            });
+            FluidUtil.getFluidContained(stack).ifPresent(this::onInsertStack);
         } else if (filter instanceof GasFilter) {
             GasStack gas = GasUtils.getGasContained(stack);
             if (gas != null) {
-                item.setValue(gas.getType().getRegistryName().toString());
+                onInsertStack(gas);
+            }
+        }
+    }
+
+    public void onInsertStack(FluidStack stack) {
+        if (stack == null || stack.isEmpty()) {
+            return;
+        }
+
+        if (filter instanceof FluidFilter) {
+            item.setValue(stack.getFluid().getRegistryName().toString());
+            if (stack.hasTag()) {
+                nbt.setValue(stack.getTag().toString());
+            } else {
                 nbt.setValue("");
             }
+        }
+    }
+
+    public void onInsertStack(GasStack stack) {
+        if (stack == null || stack.isEmpty()) {
+            return;
+        }
+
+        if (filter instanceof GasFilter) {
+            item.setValue(stack.getType().getRegistryName().toString());
+            nbt.setValue("");
         }
     }
 

--- a/src/main/java/de/maxhenkel/pipez/integration/jei/FilterScreenGhostIngredientHandler.java
+++ b/src/main/java/de/maxhenkel/pipez/integration/jei/FilterScreenGhostIngredientHandler.java
@@ -1,0 +1,41 @@
+package de.maxhenkel.pipez.integration.jei;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import de.maxhenkel.pipez.gui.FilterScreen;
+import mezz.jei.api.gui.handlers.IGhostIngredientHandler;
+import net.minecraft.client.renderer.Rect2i;
+import net.minecraft.world.item.ItemStack;
+
+public class FilterScreenGhostIngredientHandler implements IGhostIngredientHandler<FilterScreen> {
+
+    @Override
+    public <I> List<Target<I>> getTargets(FilterScreen gui, I ingredient, boolean doStart) {
+        if (ingredient instanceof ItemStack stack) {
+            List<Target<I>> list = new ArrayList<>();
+            list.add(new IGhostIngredientHandler.Target<I>() {
+
+                @Override
+                public Rect2i getArea() {
+                    return new Rect2i(gui.getGuiLeft() + 8, gui.getGuiTop() + 18, 16, 16);
+                }
+
+                @Override
+                public void accept(I ingredient) {
+                    gui.onInsertStack(stack);
+                }
+            });
+            return list;
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public void onComplete() {
+
+    }
+
+}

--- a/src/main/java/de/maxhenkel/pipez/integration/jei/FilterScreenGhostIngredientHandler.java
+++ b/src/main/java/de/maxhenkel/pipez/integration/jei/FilterScreenGhostIngredientHandler.java
@@ -1,36 +1,64 @@
 package de.maxhenkel.pipez.integration.jei;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
+import de.maxhenkel.pipez.Filter;
+import de.maxhenkel.pipez.FluidFilter;
+import de.maxhenkel.pipez.GasFilter;
 import de.maxhenkel.pipez.gui.FilterScreen;
+import de.maxhenkel.pipez.utils.GasUtils;
+import mekanism.api.chemical.gas.GasStack;
 import mezz.jei.api.gui.handlers.IGhostIngredientHandler;
 import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidUtil;
 
 public class FilterScreenGhostIngredientHandler implements IGhostIngredientHandler<FilterScreen> {
 
     @Override
     public <I> List<Target<I>> getTargets(FilterScreen gui, I ingredient, boolean doStart) {
+        Filter<?> filter = gui.getMenu().getFilter();
+        List<Target<I>> list = new ArrayList<>();
+
         if (ingredient instanceof ItemStack stack) {
-            List<Target<I>> list = new ArrayList<>();
-            list.add(new IGhostIngredientHandler.Target<I>() {
-
-                @Override
-                public Rect2i getArea() {
-                    return new Rect2i(gui.getGuiLeft() + 8, gui.getGuiTop() + 18, 16, 16);
-                }
-
-                @Override
-                public void accept(I ingredient) {
-                    gui.onInsertStack(stack);
-                }
-            });
-            return list;
-        } else {
-            return Collections.emptyList();
+            if (testItemStack(filter, stack)) {
+                list.add(this.getItemHoverAreaTarget(gui, i -> gui.onInsertStack(stack)));
+            }
+        } else if (filter instanceof FluidFilter && ingredient instanceof FluidStack stack) {
+            list.add(this.getItemHoverAreaTarget(gui, i -> gui.onInsertStack(stack)));
+        } else if (filter instanceof GasFilter && ingredient instanceof GasStack stack) {
+            list.add(this.getItemHoverAreaTarget(gui, i -> gui.onInsertStack(stack)));
         }
+
+        return list;
+    }
+
+    private boolean testItemStack(Filter<?> filter, ItemStack stack) {
+        if (filter instanceof FluidFilter) {
+            return FluidUtil.getFluidContained(stack).isPresent();
+        } else if (filter instanceof GasFilter) {
+            return GasUtils.getGasContained(stack) != null;
+        } else {
+            return true;
+        }
+    }
+
+    private <I> Target<I> getItemHoverAreaTarget(FilterScreen gui, Consumer<I> consumer) {
+        return new IGhostIngredientHandler.Target<I>() {
+
+            @Override
+            public Rect2i getArea() {
+                return new Rect2i(gui.getGuiLeft() + 8, gui.getGuiTop() + 18, 16, 16);
+            }
+
+            @Override
+            public void accept(I ingredient) {
+                consumer.accept(ingredient);
+            }
+        };
     }
 
     @Override

--- a/src/main/java/de/maxhenkel/pipez/integration/jei/JEIPlugin.java
+++ b/src/main/java/de/maxhenkel/pipez/integration/jei/JEIPlugin.java
@@ -2,6 +2,7 @@ package de.maxhenkel.pipez.integration.jei;
 
 import de.maxhenkel.pipez.Main;
 import de.maxhenkel.pipez.gui.ExtractScreen;
+import de.maxhenkel.pipez.gui.FilterScreen;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.registration.IGuiHandlerRegistration;
@@ -18,5 +19,6 @@ public class JEIPlugin implements IModPlugin {
     @Override
     public void registerGuiHandlers(IGuiHandlerRegistration registration) {
         registration.addGuiContainerHandler(ExtractScreen.class, new ExtractScreenHandler());
+        registration.addGhostIngredientHandler(FilterScreen.class, new FilterScreenGhostIngredientHandler());
     }
 }


### PR DESCRIPTION
## Description

Even if player doesn't have item for set as filter right now,
Can set filter though drag and drop item from JEI to hover area in FilterScreen.
Fluid, Gas too.

## Demo

* Item, Fluid

![Item, Fluid](https://user-images.githubusercontent.com/44163945/191239737-7a797816-1b81-417c-9608-f9f18cae95af.gif)

* Gas

![Gas](https://user-images.githubusercontent.com/44163945/191242117-b67200bd-242c-423d-af78-6cd6603ad5ba.gif)

## Changeds

1. Extract 'onInsertStack' method what use FluidStack, GasStack in FilterScreen.
2. Implemnet JEI IGhostIngredientHandler about FilterScreen.

## Note

I wrote code in 1.18.2
But port to 1.19.2 is not difficulty, I think