### PR TITLE
perf: reduce stream abuse in hot paths

### DIFF
--- a/src/main/java/de/maxhenkel/pipez/blocks/tileentity/UpgradeTileEntity.java
+++ b/src/main/java/de/maxhenkel/pipez/blocks/tileentity/UpgradeTileEntity.java
@@ -140,18 +140,16 @@ public abstract class UpgradeTileEntity extends PipeTileEntity {
 
     public List<PipeTileEntity.Connection> getSortedConnections(Direction side, PipeType pipeType) {
         UpgradeTileEntity.Distribution distribution = getDistribution(side, pipeType);
+
+        ArrayList<PipeTileEntity.Connection> sorted = new ArrayList<>(getConnections());
+
         switch (distribution) {
-            case FURTHEST:
-                return getConnections().stream().sorted((o1, o2) -> Integer.compare(o2.getDistance(), o1.getDistance())).collect(Collectors.toList());
-            case RANDOM:
-                ArrayList<PipeTileEntity.Connection> shuffle = new ArrayList<>(getConnections());
-                Collections.shuffle(shuffle);
-                return shuffle;
-            case NEAREST:
-            case ROUND_ROBIN:
-            default:
-                return getConnections().stream().sorted(Comparator.comparingInt(PipeTileEntity.Connection::getDistance)).collect(Collectors.toList());
+            case FURTHEST -> sorted.sort(Comparator.comparingInt(PipeTileEntity.Connection::getDistance).reversed());
+            case RANDOM -> Collections.shuffle(sorted);
+            default -> sorted.sort(Comparator.comparingInt(PipeTileEntity.Connection::getDistance));
         }
+
+        return sorted;
     }
 
     public enum Distribution implements ICyclable<Distribution> {

--- a/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/FluidPipeType.java
+++ b/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/FluidPipeType.java
@@ -24,7 +24,6 @@ import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class FluidPipeType extends PipeType<Fluid, FluidData> {
 
@@ -156,21 +155,7 @@ public class FluidPipeType extends PipeType<Fluid, FluidData> {
     }
 
     private boolean canInsert(HolderLookup.Provider provider, PipeTileEntity.Connection connection, FluidStack stack, List<Filter<?, ?>> filters) {
-        for (Filter<?, Fluid> filter : filters.stream().map(filter -> (Filter<?, Fluid>) filter).filter(Filter::isInvert).filter(f -> matchesConnection(connection, f)).collect(Collectors.toList())) {
-            if (matches(provider, filter, stack)) {
-                return false;
-            }
-        }
-        List<Filter<?, Fluid>> collect = filters.stream().map(filter -> (Filter<?, Fluid>) filter).filter(f -> !f.isInvert()).filter(f -> matchesConnection(connection, f)).collect(Collectors.toList());
-        if (collect.isEmpty()) {
-            return true;
-        }
-        for (Filter<?, Fluid> filter : collect) {
-            if (matches(provider, filter, stack)) {
-                return true;
-            }
-        }
-        return false;
+        return super.canInsertProto(provider, connection, stack, filters, this::matches);
     }
 
     private boolean matches(HolderLookup.Provider provider, Filter<?, Fluid> filter, FluidStack stack) {

--- a/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/GasPipeType.java
+++ b/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/GasPipeType.java
@@ -25,7 +25,6 @@ import net.neoforged.neoforge.capabilities.BlockCapability;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class GasPipeType extends PipeType<Chemical, GasData> {
 
@@ -167,21 +166,7 @@ public class GasPipeType extends PipeType<Chemical, GasData> {
     }
 
     private boolean canInsert(PipeTileEntity.Connection connection, ChemicalStack stack, List<Filter<?, ?>> filters) {
-        for (Filter<?, Chemical> filter : filters.stream().map(filter -> (Filter<?, Chemical>) filter).filter(Filter::isInvert).filter(f -> matchesConnection(connection, f)).collect(Collectors.toList())) {
-            if (matches(filter, stack)) {
-                return false;
-            }
-        }
-        List<Filter<?, Chemical>> collect = filters.stream().map(filter -> (Filter<?, Chemical>) filter).filter(f -> !f.isInvert()).filter(f -> matchesConnection(connection, f)).collect(Collectors.toList());
-        if (collect.isEmpty()) {
-            return true;
-        }
-        for (Filter<?, Chemical> filter : collect) {
-            if (matches(filter, stack)) {
-                return true;
-            }
-        }
-        return false;
+        return super.canInsertProto(connection, stack, filters, this::matches);
     }
 
     private boolean matches(Filter<?, Chemical> filter, ChemicalStack stack) {

--- a/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/ItemPipeType.java
+++ b/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/ItemPipeType.java
@@ -25,7 +25,6 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class ItemPipeType extends PipeType<Item, ItemData> {
 
@@ -182,21 +181,7 @@ public class ItemPipeType extends PipeType<Item, ItemData> {
     }
 
     private boolean canInsert(HolderLookup.Provider provider, PipeTileEntity.Connection connection, ItemStack stack, List<Filter<?, ?>> filters) {
-        for (Filter<?, Item> filter : filters.stream().map(filter -> (Filter<?, Item>) filter).filter(Filter::isInvert).filter(f -> matchesConnection(connection, f)).collect(Collectors.toList())) {
-            if (matches(provider, filter, stack)) {
-                return false;
-            }
-        }
-        List<Filter<?, Item>> collect = filters.stream().map(filter -> (Filter<?, Item>) filter).filter(f -> !f.isInvert()).filter(f -> matchesConnection(connection, f)).collect(Collectors.toList());
-        if (collect.isEmpty()) {
-            return true;
-        }
-        for (Filter<?, Item> filter : collect) {
-            if (matches(provider, filter, stack)) {
-                return true;
-            }
-        }
-        return false;
+        return super.canInsertProto(provider, connection, stack, filters, this::matches);
     }
 
     private boolean matches(HolderLookup.Provider provider, Filter<?, Item> filter, ItemStack stack) {

--- a/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/PipeType.java
+++ b/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/PipeType.java
@@ -257,24 +257,25 @@ public abstract class PipeType<T, D extends AbstractPipeTypeData<T>> {
             return true;
         }
 
-        var noUninvertedFilters = true;
+        var noNormalFilters = true;
         for (var erased : filters) {
             var filter = (Filter<?, T>) erased;
             if (!matchesConnection(connection, filter)) {
                 continue;
             }
 
-            if (!filter.isInvert()) {
-                noUninvertedFilters = false;
-                if (matcher.test(context, filter, stack)) {
-                    return true;
-                }
-            } else if (matcher.test(context, filter, stack)) {
-                return false;
+            var isNormal = !filter.isInvert();
+
+            if (matcher.test(context, filter, stack)) {
+                return isNormal;
+            }
+
+            if (isNormal) {
+                noNormalFilters = false;
             }
         }
 
-        return noUninvertedFilters;
+        return noNormalFilters;
     }
 
     final <S> boolean canInsertProto(PipeTileEntity.Connection connection, S stack, List<Filter<?, ?>> filters, BiPredicate<Filter<?, T>, S> matcher) {

--- a/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/PipeType.java
+++ b/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/PipeType.java
@@ -270,9 +270,7 @@ public abstract class PipeType<T, D extends AbstractPipeTypeData<T>> {
                 return isNormal;
             }
 
-            if (isNormal) {
-                noNormalFilters = false;
-            }
+            noNormalFilters |= isNormal;
         }
 
         return noNormalFilters;

--- a/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/PipeType.java
+++ b/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/PipeType.java
@@ -264,15 +264,11 @@ public abstract class PipeType<T, D extends AbstractPipeTypeData<T>> {
                 continue;
             }
 
-            var isNormal = !filter.isInvert();
-
             if (matcher.test(context, filter, stack)) {
-                return isNormal;
+                return !filter.isInvert();
             }
 
-            if (isNormal) {
-                noNormalFilters = false;
-            }
+            noNormalFilters &= filter.isInvert();
         }
 
         return noNormalFilters;

--- a/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/PipeType.java
+++ b/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/PipeType.java
@@ -270,7 +270,9 @@ public abstract class PipeType<T, D extends AbstractPipeTypeData<T>> {
                 return isNormal;
             }
 
-            noNormalFilters |= isNormal;
+            if (isNormal) {
+                noNormalFilters = false;
+            }
         }
 
         return noNormalFilters;

--- a/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/PipeType.java
+++ b/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/PipeType.java
@@ -16,12 +16,14 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.capabilities.BlockCapability;
+import net.neoforged.neoforge.common.util.TriPredicate;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiPredicate;
 
 public abstract class PipeType<T, D extends AbstractPipeTypeData<T>> {
 
@@ -248,5 +250,36 @@ public abstract class PipeType<T, D extends AbstractPipeTypeData<T>> {
             return;
         }
         stack.set(getDataComponentType(), (D) getOrDefault(stack).builder().distribution(value).build());
+    }
+
+    final <S, C> boolean canInsertProto(C context, PipeTileEntity.Connection connection, S stack, List<Filter<?, ?>> filters, TriPredicate<C, Filter<?, T>, S> matcher) {
+        if (filters.isEmpty()) {
+            return true;
+        }
+
+        var noUninvertedFilters = true;
+        for (var erased : filters) {
+            var filter = (Filter<?, T>) erased;
+            if (!matchesConnection(connection, filter)) {
+                continue;
+            }
+
+            if (!filter.isInvert()) {
+                noUninvertedFilters = false;
+                if (matcher.test(context, filter, stack)) {
+                    return true;
+                }
+            } else {
+                if (matcher.test(context, filter, stack)) {
+                    return false;
+                }
+            }
+        }
+
+        return noUninvertedFilters;
+    }
+
+    final <S> boolean canInsertProto(PipeTileEntity.Connection connection, S stack, List<Filter<?, ?>> filters, BiPredicate<Filter<?, T>, S> matcher) {
+        return this.canInsertProto(null, connection, stack, filters, (ignored, filter, st) -> matcher.test(filter, st));
     }
 }

--- a/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/PipeType.java
+++ b/src/main/java/de/maxhenkel/pipez/blocks/tileentity/types/PipeType.java
@@ -269,10 +269,8 @@ public abstract class PipeType<T, D extends AbstractPipeTypeData<T>> {
                 if (matcher.test(context, filter, stack)) {
                     return true;
                 }
-            } else {
-                if (matcher.test(context, filter, stack)) {
-                    return false;
-                }
+            } else if (matcher.test(context, filter, stack)) {
+                return false;
             }
         }
 


### PR DESCRIPTION
removes abuses of streams in `UpgradeTileEntity#getSortedConnections` and various `*PipeType#canInsert` implementations, which should reduce allocation rate and lead to increased performance