### PR TITLE
feat: Add configurable filter limits

### DIFF
--- a/src/main/java/de/maxhenkel/pipez/ServerConfig.java
+++ b/src/main/java/de/maxhenkel/pipez/ServerConfig.java
@@ -3,6 +3,8 @@ package de.maxhenkel.pipez;
 import de.maxhenkel.corelib.config.ConfigBase;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
+import javax.annotation.Nullable;
+
 public class ServerConfig extends ConfigBase {
 
     public final ModConfigSpec.IntValue itemPipeSpeed;
@@ -33,6 +35,12 @@ public class ServerConfig extends ConfigBase {
     public final ModConfigSpec.IntValue gasPipeAmountImproved;
     public final ModConfigSpec.IntValue gasPipeAmountAdvanced;
     public final ModConfigSpec.IntValue gasPipeAmountUltimate;
+
+    public final ModConfigSpec.IntValue filterLimitBasic;
+    public final ModConfigSpec.IntValue filterLimitImproved;
+    public final ModConfigSpec.IntValue filterLimitAdvanced;
+    public final ModConfigSpec.IntValue filterLimitUltimate;
+    public final ModConfigSpec.IntValue filterLimitInfinity;
 
     public ServerConfig(ModConfigSpec.Builder builder) {
         super(builder);
@@ -135,6 +143,45 @@ public class ServerConfig extends ConfigBase {
         gasPipeAmountUltimate = builder
                 .comment("The amount of mB transferred each tick", "Only available if Mekanism is installed")
                 .defineInRange("gas_pipe.amount.ultimate", 40000, 1, Integer.MAX_VALUE);
+
+        filterLimitBasic = builder
+                .comment("The maximum amount of filters per basic upgrade")
+                .defineInRange("filter.limit.basic", 16, 0, Integer.MAX_VALUE);
+
+        filterLimitImproved = builder
+                .comment("The maximum amount of filters per improved upgrade")
+                .defineInRange("filter.limit.improved", 32, 0, Integer.MAX_VALUE);
+
+        filterLimitAdvanced = builder
+                .comment("The maximum amount of filters per advanced upgrade")
+                .defineInRange("filter.limit.advanced", 64, 0, Integer.MAX_VALUE);
+
+        filterLimitUltimate = builder
+                .comment("The maximum amount of filters per ultimate upgrade")
+                .defineInRange("filter.limit.ultimate", 128, 0, Integer.MAX_VALUE);
+
+        filterLimitInfinity = builder
+                .comment("The maximum amount of filters per infinity upgrade")
+                .defineInRange("filter.limit.infinity", 256, 0, Integer.MAX_VALUE);
+    }
+
+    public int getFilterLimit(@Nullable Upgrade upgrade) {
+        if (upgrade == null) {
+            return 0;
+        }
+        switch (upgrade) {
+            case BASIC:
+                return filterLimitBasic.get();
+            case IMPROVED:
+                return filterLimitImproved.get();
+            case ADVANCED:
+                return filterLimitAdvanced.get();
+            case ULTIMATE:
+                return filterLimitUltimate.get();
+            case INFINITY:
+            default:
+                return filterLimitInfinity.get();
+        }
     }
 
 }

--- a/src/main/java/de/maxhenkel/pipez/net/UpdateFilterMessage.java
+++ b/src/main/java/de/maxhenkel/pipez/net/UpdateFilterMessage.java
@@ -5,10 +5,12 @@ import de.maxhenkel.pipez.Filter;
 import de.maxhenkel.pipez.PipezMod;
 import de.maxhenkel.pipez.blocks.tileentity.types.PipeType;
 import de.maxhenkel.pipez.gui.ExtractContainer;
+import de.maxhenkel.pipez.gui.FilterContainer;
 import de.maxhenkel.pipez.gui.IPipeContainer;
 import de.maxhenkel.pipez.gui.containerfactory.PipeContainerProvider;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.Identifier;
@@ -49,7 +51,7 @@ public class UpdateFilterMessage implements Message<UpdateFilterMessage> {
             return;
         }
         PipeType<?, ?>[] pipeTypes = pipeContainer.getPipe().getPipeTypes();
-        if (index >= pipeTypes.length) {
+        if (index < 0 || index >= pipeTypes.length) {
             return;
         }
         PipeType<?, ?> pipeType = pipeTypes[index];
@@ -70,6 +72,14 @@ public class UpdateFilterMessage implements Message<UpdateFilterMessage> {
                 filters.add(filter);
             }
         } else {
+            int filterLimit = PipezMod.SERVER_CONFIG.getFilterLimit(pipeContainer.getPipe().getUpgrade(pipeContainer.getSide()));
+            if (filters.size() >= filterLimit) {
+                sender.sendSystemMessage(Component.translatable("message.pipez.filter.limit_reached", filterLimit));
+                if (sender.containerMenu instanceof FilterContainer) {
+                    PipeContainerProvider.openGui(sender, pipeContainer.getPipe(), pipeContainer.getSide(), index, (id, playerInventory, playerEntity) -> new ExtractContainer(id, playerInventory, pipeContainer.getPipe(), pipeContainer.getSide(), index));
+                }
+                return;
+            }
             filters.add(filter);
         }
         pipeContainer.getPipe().setFilters(pipeContainer.getSide(), pipeType, filters);

--- a/src/main/resources/assets/pipez/lang/en_us.json
+++ b/src/main/resources/assets/pipez/lang/en_us.json
@@ -74,6 +74,7 @@
   "message.pipez.filter.add": "Add",
   "message.pipez.filter.edit": "Edit",
   "message.pipez.filter.remove": "Remove",
+  "message.pipez.filter.limit_reached": "Filter limit reached (%s)",
   "message.pipez.filter.cancel": "Cancel",
   "message.pipez.filter.submit": "Submit",
   "message.pipez.filter.item_tag": "Item/Tag",


### PR DESCRIPTION
## Summary
Add server config options for per-upgrade filter limits
Enforce filter limits server-side when adding new filters
Show a message when the filter limit is reached

Existing filters are not removed if a server lowers the configured limit. 
Editing and removing existing filters remain allowed.

## Testing
No units, just ran complie

## Issue
close #284 